### PR TITLE
LPS-76859 Added z-index to '.dropdown' to display ellipsis in front o…

### DIFF
--- a/src/scss/bootstrap/_dropdown.scss
+++ b/src/scss/bootstrap/_dropdown.scss
@@ -2,6 +2,7 @@
 .dropup,
 .dropdown {
   position: relative;
+  z-index: 1;
 }
 
 .dropdown-toggle {


### PR DESCRIPTION
…f cards in Web Content

Web contents with class="cards" will cover the ellipses and prevent user to edit the web content, template, and permissions.

By adding the z-index, the ellipses will be in front of the card and clickable.